### PR TITLE
Don't load initial crawler data

### DIFF
--- a/internal/metrics/crawler.go
+++ b/internal/metrics/crawler.go
@@ -70,11 +70,8 @@ func (s *CrawlerServiceMetrics) initMaxmindDB() error {
 	return nil
 }
 
-// InitialData is called on startup of the metrics server, to allow seeding metrics with
-// current/initial data
-func (s *CrawlerServiceMetrics) InitialData() {
-	utils.LogErr(s.metrics.client.CrawlerService.GetPeerCounts())
-}
+// InitialData is called on startup of the metrics server, to allow seeding metrics with current/initial data
+func (s *CrawlerServiceMetrics) InitialData() {}
 
 // ReceiveResponse handles crawler responses that are returned over the websocket
 func (s *CrawlerServiceMetrics) ReceiveResponse(resp *types.WebsocketResponse) {


### PR DESCRIPTION
When crawler is starting, it will send an event once data is loaded, and this is the best time to load more data, or else, load more after every crawl cycle.
Until then, metrics will be null and prom will just skip the timeframe