### PR TITLE
Disconnect reset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/chia-network/chia-exporter
 go 1.17
 
 require (
-	github.com/chia-network/go-chia-libs v0.0.0-20220225203003-41f2fad5a3e8
+	github.com/chia-network/go-chia-libs v0.0.0-20220315010935-f83139bbcc00
 	github.com/oschwald/maxminddb-golang v1.8.0
 	github.com/prometheus/client_golang v1.12.0
 	github.com/spf13/cobra v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chia-network/go-chia-libs v0.0.0-20220225203003-41f2fad5a3e8 h1:4KRulxtckoY/42JWYor9d0vAnOVjdSV6SLgiBJ75tNM=
-github.com/chia-network/go-chia-libs v0.0.0-20220225203003-41f2fad5a3e8/go.mod h1:h1y8enwmbHVylzRDd5jA9C7RZMXX82pV8/rviB7L4V8=
+github.com/chia-network/go-chia-libs v0.0.0-20220315010935-f83139bbcc00 h1:C8XRe0ptpS2m64pCe+mBFYilWWrbj2zAT2T8YP5LLs4=
+github.com/chia-network/go-chia-libs v0.0.0-20220315010935-f83139bbcc00/go.mod h1:h1y8enwmbHVylzRDd5jA9C7RZMXX82pV8/rviB7L4V8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/internal/metrics/crawler.go
+++ b/internal/metrics/crawler.go
@@ -73,6 +73,15 @@ func (s *CrawlerServiceMetrics) initMaxmindDB() error {
 // InitialData is called on startup of the metrics server, to allow seeding metrics with current/initial data
 func (s *CrawlerServiceMetrics) InitialData() {}
 
+func (s *CrawlerServiceMetrics) Disconnected() {
+	s.totalNodes5Days.Unregister()
+	s.reliableNodes.Unregister()
+	s.ipv4Nodes5Days.Unregister()
+	s.ipv6Nodes5Days.Unregister()
+	s.versionBuckets.Reset()
+	s.countryNodeCountBuckets.Reset()
+}
+
 // ReceiveResponse handles crawler responses that are returned over the websocket
 func (s *CrawlerServiceMetrics) ReceiveResponse(resp *types.WebsocketResponse) {
 	switch resp.Command {

--- a/internal/metrics/crawler.go
+++ b/internal/metrics/crawler.go
@@ -73,6 +73,7 @@ func (s *CrawlerServiceMetrics) initMaxmindDB() error {
 // InitialData is called on startup of the metrics server, to allow seeding metrics with current/initial data
 func (s *CrawlerServiceMetrics) InitialData() {}
 
+// Disconnected clears/unregisters metrics when the connection drops
 func (s *CrawlerServiceMetrics) Disconnected() {
 	s.totalNodes5Days.Unregister()
 	s.reliableNodes.Unregister()

--- a/internal/metrics/fullnode.go
+++ b/internal/metrics/fullnode.go
@@ -92,6 +92,33 @@ func (s *FullNodeServiceMetrics) InitialData() {
 	s.RequestBlockCountMetrics()
 }
 
+func (s *FullNodeServiceMetrics) Disconnected() {
+	s.difficulty.Unregister()
+	s.mempoolCost.Unregister()
+	s.mempoolMinFee.Reset()
+	s.mempoolSize.Unregister()
+	s.mempoolMaxTotalCost.Unregister()
+	s.netspaceMiB.Unregister()
+	s.nodeHeight.Unregister()
+	s.nodeHeightSynced.Unregister()
+	s.nodeSynced.Unregister()
+
+	s.compactBlocks.Unregister()
+	s.uncompactBlocks.Unregister()
+	s.hintCount.Unregister()
+
+	s.connectionCount.Reset()
+
+	s.maxBlockCost.Unregister()
+	s.blockCost.Unregister()
+	s.blockCost.Unregister()
+	s.kSize.Reset()
+
+	s.totalSignagePoints.Unregister()
+	s.signagePointsSubSlot.Unregister()
+	s.currentSignagePoint.Unregister()
+}
+
 // ReceiveResponse handles full node related responses that are returned over the websocket
 func (s *FullNodeServiceMetrics) ReceiveResponse(resp *types.WebsocketResponse) {
 	switch resp.Command {

--- a/internal/metrics/fullnode.go
+++ b/internal/metrics/fullnode.go
@@ -92,6 +92,7 @@ func (s *FullNodeServiceMetrics) InitialData() {
 	s.RequestBlockCountMetrics()
 }
 
+// Disconnected clears/unregisters metrics when the connection drops
 func (s *FullNodeServiceMetrics) Disconnected() {
 	s.difficulty.Unregister()
 	s.mempoolCost.Unregister()
@@ -111,7 +112,7 @@ func (s *FullNodeServiceMetrics) Disconnected() {
 
 	s.maxBlockCost.Unregister()
 	s.blockCost.Unregister()
-	s.blockCost.Unregister()
+	s.blockFees.Unregister()
 	s.kSize.Reset()
 
 	s.totalSignagePoints.Unregister()

--- a/internal/metrics/timelord.go
+++ b/internal/metrics/timelord.go
@@ -39,6 +39,13 @@ func (s *TimelordServiceMetrics) InitialData() {
 	utils.LogErr(s.metrics.client.CrawlerService.GetPeerCounts())
 }
 
+func (s *TimelordServiceMetrics) Disconnected() {
+	s.fastestTimelord.Unregister()
+	s.slowTimelord.Unregister()
+	s.estimatedIPS.Unregister()
+	s.compactProofsFound.Reset()
+}
+
 // ReceiveResponse handles crawler responses that are returned over the websocket
 func (s *TimelordServiceMetrics) ReceiveResponse(resp *types.WebsocketResponse) {
 	//("finished_pot_challenge", "new_compact_proof", "skipping_peak", "new_peak")

--- a/internal/metrics/timelord.go
+++ b/internal/metrics/timelord.go
@@ -39,6 +39,7 @@ func (s *TimelordServiceMetrics) InitialData() {
 	utils.LogErr(s.metrics.client.CrawlerService.GetPeerCounts())
 }
 
+// Disconnected clears/unregisters metrics when the connection drops
 func (s *TimelordServiceMetrics) Disconnected() {
 	s.fastestTimelord.Unregister()
 	s.slowTimelord.Unregister()

--- a/internal/metrics/wallet.go
+++ b/internal/metrics/wallet.go
@@ -52,6 +52,7 @@ func (s *WalletServiceMetrics) InitialData() {
 	utils.LogErr(s.metrics.client.WalletService.GetSyncStatus())
 }
 
+// Disconnected clears/unregisters metrics when the connection drops
 func (s *WalletServiceMetrics) Disconnected() {
 	s.walletSynced.Unregister()
 	s.confirmedBalance.Reset()

--- a/internal/metrics/wallet.go
+++ b/internal/metrics/wallet.go
@@ -23,7 +23,6 @@ type WalletServiceMetrics struct {
 	// WalletBalanceMetrics
 	walletSynced            *wrappedPrometheus.LazyGauge
 	confirmedBalance        *prometheus.GaugeVec
-	pendingBalance          *prometheus.GaugeVec
 	spendableBalance        *prometheus.GaugeVec
 	maxSendAmount           *prometheus.GaugeVec
 	pendingCoinRemovalCount *prometheus.GaugeVec
@@ -51,6 +50,15 @@ func (s *WalletServiceMetrics) InitialData() {
 	// Otherwise some other consistent identifier would be very useful for historical metrics across different nodes
 	utils.LogErr(s.metrics.client.WalletService.GetWalletBalance(&rpc.GetWalletBalanceOptions{WalletID: 1}))
 	utils.LogErr(s.metrics.client.WalletService.GetSyncStatus())
+}
+
+func (s *WalletServiceMetrics) Disconnected() {
+	s.walletSynced.Unregister()
+	s.confirmedBalance.Reset()
+	s.spendableBalance.Reset()
+	s.maxSendAmount.Reset()
+	s.pendingCoinRemovalCount.Reset()
+	s.unspentCoinCount.Reset()
 }
 
 // ReceiveResponse handles wallet responses that are returned over the websocket

--- a/internal/prometheus/lazycounter.go
+++ b/internal/prometheus/lazycounter.go
@@ -33,3 +33,11 @@ func (l *LazyCounter) Add(val float64) {
 
 	l.Counter.Add(val)
 }
+
+// Unregister removes the metric from the Registry to stop reporting it until it is registered again
+func (l *LazyCounter) Unregister() {
+	if l.registered == true {
+		l.registered = false
+		l.Registry.Unregister(l.Counter)
+	}
+}


### PR DESCRIPTION
When the websocket disconnects, clear all registered metrics so they are no longer reported at the /metrics endpoint