### PR TITLE
Http client option

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -43,6 +43,11 @@ type Metrics struct {
 	metricsPort uint16
 	client      *rpc.Client
 
+	// httpClient is another instance of the rpc.Client in HTTP mode
+	// This is used rarely, to request data in response to a websocket event that is too large to fit on a single
+	// websocket connection or needs to be paginated
+	httpClient  *rpc.Client
+
 	// This holds a custom prometheus registry so that only our metrics are exported, and not the default go metrics
 	registry *prometheus.Registry
 
@@ -62,6 +67,11 @@ func NewMetrics(port uint16) (*Metrics, error) {
 	}
 
 	metrics.client, err = rpc.NewClient(rpc.ConnectionModeWebsocket)
+	if err != nil {
+		return nil, err
+	}
+
+	metrics.httpClient, err = rpc.NewClient(rpc.ConnectionModeHTTP)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -46,7 +46,7 @@ type Metrics struct {
 	// httpClient is another instance of the rpc.Client in HTTP mode
 	// This is used rarely, to request data in response to a websocket event that is too large to fit on a single
 	// websocket connection or needs to be paginated
-	httpClient  *rpc.Client
+	httpClient *rpc.Client
 
 	// This holds a custom prometheus registry so that only our metrics are exported, and not the default go metrics
 	registry *prometheus.Registry


### PR DESCRIPTION
Use http client instead of websocket client to get the list of IPs after a timestamp, to avoid running into the websocket message size limit