### PR TITLE
Add logrus + ability to set log-level with flags/env/config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ $(BIN)/%: | $(BIN) ; $(info $(M) building $(PACKAGE)…)
 GOLINT = $(BIN)/golint
 $(BIN)/golint: PACKAGE=golang.org/x/lint/golint
 
+STATICCHECK = $(BIN)/staticcheck
+$(BIN)/staticcheck: PACKAGE=honnef.co/go/tools/cmd/staticcheck
+
 GOCOV = $(BIN)/gocov
 $(BIN)/gocov: PACKAGE=github.com/axw/gocov/...
 
@@ -54,10 +57,10 @@ test-verbose: ARGS=-v            ## Run tests in verbose mode with coverage repo
 test-race:    ARGS=-race         ## Run tests with race detector
 $(TEST_TARGETS): NAME=$(MAKECMDGOALS:test-%=%)
 $(TEST_TARGETS): test
-check test tests: fmt lint vet; $(info $(M) running $(NAME:%=% )tests…) @ ## Run tests
+check test tests: fmt lint vet staticcheck; $(info $(M) running $(NAME:%=% )tests…) @ ## Run tests
 	$Q $(GO) test -timeout $(TIMEOUT)s $(ARGS) $(TESTPKGS)
 
-test-xml: fmt lint vet | $(GO2XUNIT) ; $(info $(M) running xUnit tests…) @ ## Run tests with xUnit output
+test-xml: fmt lint vet staticcheck | $(GO2XUNIT) ; $(info $(M) running xUnit tests…) @ ## Run tests with xUnit output
 	$Q mkdir -p test
 	$Q 2>&1 $(GO) test -timeout $(TIMEOUT)s -v $(TESTPKGS) | tee test/tests.output
 	$(GO2XUNIT) -fail -input test/tests.output -output test/tests.xml
@@ -69,7 +72,7 @@ COVERAGE_HTML    = $(COVERAGE_DIR)/index.html
 .PHONY: test-coverage test-coverage-tools
 test-coverage-tools: | $(GOCOV) $(GOCOVXML)
 test-coverage: COVERAGE_DIR := $(CURDIR)/test/coverage
-test-coverage: fmt lint vet test-coverage-tools ; $(info $(M) running coverage tests…) @ ## Run coverage tests
+test-coverage: fmt lint vet staticcheck test-coverage-tools ; $(info $(M) running coverage tests…) @ ## Run coverage tests
 	$Q mkdir -p $(COVERAGE_DIR)
 	$Q $(GO) test \
 		-coverpkg=$$($(GO) list -f '{{ join .Deps "\n" }}' $(TESTPKGS) | \
@@ -91,6 +94,10 @@ fmt: ; $(info $(M) running gofmt…) @ ## Run gofmt on all source files
 .PHONY: vet
 vet: ; $(info $(M) running go vet…) @ ## Run go vet on all source files
 	$Q $(GO) vet $(PKGS)
+
+.PHONY: staticcheck
+staticcheck: | $(STATICCHECK) ; $(info $(M) running staticcheck…) @
+	$Q $(STATICCHECK) $(PKGS)
 
 # Misc
 

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ $(BIN)/golint: PACKAGE=golang.org/x/lint/golint
 STATICCHECK = $(BIN)/staticcheck
 $(BIN)/staticcheck: PACKAGE=honnef.co/go/tools/cmd/staticcheck
 
+ERRCHECK = $(BIN)/errcheck
+$(BIN)/errcheck: PACKAGE=github.com/kisielk/errcheck
+
 GOCOV = $(BIN)/gocov
 $(BIN)/gocov: PACKAGE=github.com/axw/gocov/...
 
@@ -57,10 +60,10 @@ test-verbose: ARGS=-v            ## Run tests in verbose mode with coverage repo
 test-race:    ARGS=-race         ## Run tests with race detector
 $(TEST_TARGETS): NAME=$(MAKECMDGOALS:test-%=%)
 $(TEST_TARGETS): test
-check test tests: fmt lint vet staticcheck; $(info $(M) running $(NAME:%=% )tests…) @ ## Run tests
+check test tests: fmt lint vet staticcheck errcheck; $(info $(M) running $(NAME:%=% )tests…) @ ## Run tests
 	$Q $(GO) test -timeout $(TIMEOUT)s $(ARGS) $(TESTPKGS)
 
-test-xml: fmt lint vet staticcheck | $(GO2XUNIT) ; $(info $(M) running xUnit tests…) @ ## Run tests with xUnit output
+test-xml: fmt lint vet staticcheck errcheck | $(GO2XUNIT) ; $(info $(M) running xUnit tests…) @ ## Run tests with xUnit output
 	$Q mkdir -p test
 	$Q 2>&1 $(GO) test -timeout $(TIMEOUT)s -v $(TESTPKGS) | tee test/tests.output
 	$(GO2XUNIT) -fail -input test/tests.output -output test/tests.xml
@@ -72,7 +75,7 @@ COVERAGE_HTML    = $(COVERAGE_DIR)/index.html
 .PHONY: test-coverage test-coverage-tools
 test-coverage-tools: | $(GOCOV) $(GOCOVXML)
 test-coverage: COVERAGE_DIR := $(CURDIR)/test/coverage
-test-coverage: fmt lint vet staticcheck test-coverage-tools ; $(info $(M) running coverage tests…) @ ## Run coverage tests
+test-coverage: fmt lint vet staticcheck errcheck test-coverage-tools ; $(info $(M) running coverage tests…) @ ## Run coverage tests
 	$Q mkdir -p $(COVERAGE_DIR)
 	$Q $(GO) test \
 		-coverpkg=$$($(GO) list -f '{{ join .Deps "\n" }}' $(TESTPKGS) | \
@@ -98,6 +101,10 @@ vet: ; $(info $(M) running go vet…) @ ## Run go vet on all source files
 .PHONY: staticcheck
 staticcheck: | $(STATICCHECK) ; $(info $(M) running staticcheck…) @
 	$Q $(STATICCHECK) $(PKGS)
+
+.PHONY: errcheck
+errcheck: | $(ERRCHECK) ; $(info $(M) running errcheck…) @
+	$Q $(ERRCHECK) $(PKGS)
 
 # Misc
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -40,9 +41,18 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&maxmindDBPath, "maxmind-db-path", "", "Path to the maxmind database file")
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "How verbose the logs should be. panic, fatal, error, warn, info, debug, trace")
 
-	viper.BindPFlag("metrics-port", rootCmd.PersistentFlags().Lookup("metrics-port"))
-	viper.BindPFlag("maxmind-db-path", rootCmd.PersistentFlags().Lookup("maxmind-db-path"))
-	viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level"))
+	err := viper.BindPFlag("metrics-port", rootCmd.PersistentFlags().Lookup("metrics-port"))
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+	err = viper.BindPFlag("maxmind-db-path", rootCmd.PersistentFlags().Lookup("maxmind-db-path"))
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+	err = viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level"))
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,6 +30,7 @@ func init() {
 	var (
 		metricsPort   int
 		maxmindDBPath string
+		logLevel      string
 	)
 
 	cobra.OnInitialize(initConfig)
@@ -37,9 +38,11 @@ func init() {
 
 	rootCmd.PersistentFlags().IntVar(&metricsPort, "metrics-port", 9914, "The port the metrics server binds to")
 	rootCmd.PersistentFlags().StringVar(&maxmindDBPath, "maxmind-db-path", "", "Path to the maxmind database file")
+	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "How verbose the logs should be. panic, fatal, error, warn, info, debug, trace")
 
 	viper.BindPFlag("metrics-port", rootCmd.PersistentFlags().Lookup("metrics-port"))
 	viper.BindPFlag("maxmind-db-path", rootCmd.PersistentFlags().Lookup("maxmind-db-path"))
+	viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level"))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/chia-network/go-chia-libs v0.0.3
 	github.com/oschwald/maxminddb-golang v1.8.0
 	github.com/prometheus/client_golang v1.12.0
+	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.1
 )

--- a/go.sum
+++ b/go.sum
@@ -348,6 +348,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=

--- a/internal/metrics/crawler.go
+++ b/internal/metrics/crawler.go
@@ -3,9 +3,10 @@ package metrics
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/chia-network/go-chia-libs/pkg/rpc"
 	"github.com/chia-network/go-chia-libs/pkg/types"
@@ -49,7 +50,7 @@ func (s *CrawlerServiceMetrics) InitMetrics() {
 	err := s.initMaxmindDB()
 	if err != nil {
 		// Continue on maxmind error - optional/not critical functionality
-		log.Printf("Error initializing maxmind DB: %s\n", err.Error())
+		log.Errorf("Error initializing maxmind DB: %s\n", err.Error())
 	}
 }
 
@@ -99,7 +100,7 @@ func (s *CrawlerServiceMetrics) GetPeerCounts(resp *types.WebsocketResponse) {
 	counts := &rpc.GetPeerCountsResponse{}
 	err := json.Unmarshal(resp.Data, counts)
 	if err != nil {
-		log.Printf("Error unmarshalling: %s\n", err.Error())
+		log.Errorf("Error unmarshalling: %s\n", err.Error())
 		return
 	}
 
@@ -137,7 +138,7 @@ func (s *CrawlerServiceMetrics) StartIPCountryMapping(limit uint) {
 		Limit: limit,
 	})
 	if err != nil {
-		log.Printf("Error getting IPs: %s\n", err.Error())
+		log.Errorf("Error getting IPs: %s\n", err.Error())
 		return
 	}
 

--- a/internal/metrics/crawler.go
+++ b/internal/metrics/crawler.go
@@ -170,7 +170,7 @@ func (s *CrawlerServiceMetrics) GetIPsAfterTimestamp(ips *rpc.GetIPsAfterTimesta
 		}
 
 		countryName := ""
-		countryName, _ = country.Country.Names["en"]
+		countryName = country.Country.Names["en"]
 
 		if _, ok := countryCounts[country.Country.ISOCode]; !ok {
 			countryCounts[country.Country.ISOCode] = &countStruct{

--- a/internal/metrics/fullnode.go
+++ b/internal/metrics/fullnode.go
@@ -150,7 +150,7 @@ func (s *FullNodeServiceMetrics) GetBlockchainState(resp *types.WebsocketRespons
 	}
 
 	if state.BlockchainState.Sync != nil {
-		if state.BlockchainState.Sync.Synced == true {
+		if state.BlockchainState.Sync.Synced {
 			s.nodeSynced.Set(1)
 		} else {
 			s.nodeSynced.Set(0)
@@ -235,7 +235,7 @@ func (s *FullNodeServiceMetrics) Block(resp *types.WebsocketResponse) {
 
 	s.kSize.WithLabelValues(fmt.Sprintf("%d", block.KSize)).Inc()
 
-	if block.TransactionBlock == true {
+	if block.TransactionBlock {
 		s.blockCost.Set(float64(block.BlockCost))
 		s.blockFees.Set(float64(block.BlockFees))
 	}

--- a/internal/metrics/fullnode.go
+++ b/internal/metrics/fullnode.go
@@ -3,7 +3,8 @@ package metrics
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/chia-network/go-chia-libs/pkg/rpc"
 	"github.com/chia-network/go-chia-libs/pkg/types"
@@ -144,7 +145,7 @@ func (s *FullNodeServiceMetrics) GetBlockchainState(resp *types.WebsocketRespons
 	state := &types.WebsocketBlockchainState{}
 	err := json.Unmarshal(resp.Data, state)
 	if err != nil {
-		log.Printf("Error unmarshalling: %s\n", err.Error())
+		log.Errorf("Error unmarshalling: %s\n", err.Error())
 		return
 	}
 
@@ -185,7 +186,7 @@ func (s *FullNodeServiceMetrics) GetConnections(resp *types.WebsocketResponse) {
 	connections := &rpc.GetConnectionsResponse{}
 	err := json.Unmarshal(resp.Data, connections)
 	if err != nil {
-		log.Printf("Error unmarshalling: %s\n", err.Error())
+		log.Errorf("Error unmarshalling: %s\n", err.Error())
 		return
 	}
 
@@ -228,7 +229,7 @@ func (s *FullNodeServiceMetrics) Block(resp *types.WebsocketResponse) {
 	block := &types.BlockEvent{}
 	err := json.Unmarshal(resp.Data, block)
 	if err != nil {
-		log.Printf("Error unmarshalling: %s\n", err.Error())
+		log.Errorf("Error unmarshalling: %s\n", err.Error())
 		return
 	}
 
@@ -246,7 +247,7 @@ func (s *FullNodeServiceMetrics) GetBlockCountMetrics(resp *types.WebsocketRespo
 	blockMetrics := &rpc.GetBlockCountMetricsResponse{}
 	err := json.Unmarshal(resp.Data, blockMetrics)
 	if err != nil {
-		log.Printf("Error unmarshalling: %s\n", err.Error())
+		log.Errorf("Error unmarshalling: %s\n", err.Error())
 		return
 	}
 
@@ -262,7 +263,7 @@ func (s *FullNodeServiceMetrics) SignagePoint(resp *types.WebsocketResponse) {
 	signagePoint := &types.SignagePointEvent{}
 	err := json.Unmarshal(resp.Data, signagePoint)
 	if err != nil {
-		log.Printf("Error unmarshalling: %s\n", err.Error())
+		log.Errorf("Error unmarshalling: %s\n", err.Error())
 		return
 	}
 

--- a/internal/metrics/timelord.go
+++ b/internal/metrics/timelord.go
@@ -2,7 +2,8 @@ package metrics
 
 import (
 	"encoding/json"
-	"log"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/chia-network/go-chia-libs/pkg/types"
 	"github.com/prometheus/client_golang/prometheus"
@@ -67,7 +68,7 @@ func (s *TimelordServiceMetrics) FinishedPoT(resp *types.WebsocketResponse) {
 	potEvent := &types.FinishedPoTEvent{}
 	err := json.Unmarshal(resp.Data, potEvent)
 	if err != nil {
-		log.Printf("Error unmarshalling: %s\n", err.Error())
+		log.Errorf("Error unmarshalling: %s\n", err.Error())
 		return
 	}
 	s.estimatedIPS.Set(potEvent.EstimatedIPS)
@@ -78,7 +79,7 @@ func (s *TimelordServiceMetrics) NewCompactProof(resp *types.WebsocketResponse) 
 	compactProof := &types.NewCompactProofEvent{}
 	err := json.Unmarshal(resp.Data, compactProof)
 	if err != nil {
-		log.Printf("Error unmarshalling: %s\n", err.Error())
+		log.Errorf("Error unmarshalling: %s\n", err.Error())
 		return
 	}
 

--- a/internal/metrics/wallet.go
+++ b/internal/metrics/wallet.go
@@ -3,7 +3,8 @@ package metrics
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/chia-network/go-chia-libs/pkg/rpc"
 	"github.com/chia-network/go-chia-libs/pkg/types"
@@ -81,7 +82,7 @@ func (s *WalletServiceMetrics) CoinAdded(resp *types.WebsocketResponse) {
 	coinAdded := &types.CoinAddedEvent{}
 	err := json.Unmarshal(resp.Data, coinAdded)
 	if err != nil {
-		log.Printf("Error unmarshalling: %s\n", err.Error())
+		log.Errorf("Error unmarshalling: %s\n", err.Error())
 		return
 	}
 
@@ -100,7 +101,7 @@ func (s *WalletServiceMetrics) GetSyncStatus(resp *types.WebsocketResponse) {
 	syncStatusResponse := &rpc.GetWalletSyncStatusResponse{}
 	err := json.Unmarshal(resp.Data, syncStatusResponse)
 	if err != nil {
-		log.Printf("Error unmarshalling: %s\n", err.Error())
+		log.Errorf("Error unmarshalling: %s\n", err.Error())
 		return
 	}
 
@@ -116,7 +117,7 @@ func (s *WalletServiceMetrics) GetWalletBalance(resp *types.WebsocketResponse) {
 	walletBalance := &rpc.GetWalletBalanceResponse{}
 	err := json.Unmarshal(resp.Data, walletBalance)
 	if err != nil {
-		log.Printf("Error unmarshalling: %s\n", err.Error())
+		log.Errorf("Error unmarshalling: %s\n", err.Error())
 		return
 	}
 

--- a/internal/prometheus/lazycounter.go
+++ b/internal/prometheus/lazycounter.go
@@ -16,7 +16,7 @@ type LazyCounter struct {
 
 // Inc wraps prometheus.Counter.Inc with a call to MustRegister
 func (l *LazyCounter) Inc() {
-	if l.registered != true {
+	if !l.registered {
 		l.registered = true
 		l.Registry.MustRegister(l.Counter)
 	}
@@ -26,7 +26,7 @@ func (l *LazyCounter) Inc() {
 
 // Add wraps prometheus.Counter.Add with a call to MustRegister
 func (l *LazyCounter) Add(val float64) {
-	if l.registered != true {
+	if !l.registered {
 		l.registered = true
 		l.Registry.MustRegister(l.Counter)
 	}
@@ -36,7 +36,7 @@ func (l *LazyCounter) Add(val float64) {
 
 // Unregister removes the metric from the Registry to stop reporting it until it is registered again
 func (l *LazyCounter) Unregister() {
-	if l.registered == true {
+	if l.registered {
 		l.registered = false
 		l.Registry.Unregister(l.Counter)
 	}

--- a/internal/prometheus/lazygauge.go
+++ b/internal/prometheus/lazygauge.go
@@ -16,7 +16,7 @@ type LazyGauge struct {
 
 // Set wraps prometheus.Set with a call to MustRegister
 func (l *LazyGauge) Set(val float64) {
-	if l.registered != true {
+	if !l.registered {
 		l.registered = true
 		l.Registry.MustRegister(l.Gauge)
 	}
@@ -26,7 +26,7 @@ func (l *LazyGauge) Set(val float64) {
 
 // Unregister removes the metric from the Registry to stop reporting it until it is registered again
 func (l *LazyGauge) Unregister() {
-	if l.registered == true {
+	if l.registered {
 		l.registered = false
 		l.Registry.Unregister(l.Gauge)
 	}

--- a/internal/utils/error.go
+++ b/internal/utils/error.go
@@ -1,10 +1,10 @@
 package utils
 
-import "log"
+import log "github.com/sirupsen/logrus"
 
 // LogErr logs an error if there's an error and the continues
 func LogErr(_, _ interface{}, err error) {
 	if err != nil {
-		log.Printf("Error requesting connections: %s\n", err.Error())
+		log.Errorf("%s\n", err.Error())
 	}
 }


### PR DESCRIPTION
Default log level is `info`

`--log-level debug` currently adds additional logging around the specific data received in each response

Also adds additional tools to the Makefile + fixes for them:
* staticcheck
* errcheck