### PR TITLE
Set total plots from the get plots endpoint as well

### DIFF
--- a/internal/metrics/harvester.go
+++ b/internal/metrics/harvester.go
@@ -160,6 +160,7 @@ func (s *HarvesterServiceMetrics) ProcessGetPlots(plots *rpc.HarvesterGetPlotsRe
 
 	s.totalPoolPlots.Set(float64(poolPlotCount))
 	s.totalOGPlots.Set(float64(ogPlotCount))
+	s.totalPlots.Set(float64(ogPlotCount + poolPlotCount))
 
 	s.totalPlotsValue = uint64(len(plots.Plots))
 }


### PR DESCRIPTION
Ensures that total plots is set even if just from the initial data (not in response to a farming info event)