### PR TITLE
Add debug metric handler

### DIFF
--- a/internal/metrics/crawler.go
+++ b/internal/metrics/crawler.go
@@ -37,6 +37,9 @@ type CrawlerServiceMetrics struct {
 	ipv6Nodes5Days          *wrappedPrometheus.LazyGauge
 	versionBuckets          *prometheus.GaugeVec
 	countryNodeCountBuckets *prometheus.GaugeVec
+
+	// Debug Metric
+	debug *prometheus.GaugeVec
 }
 
 // InitMetrics sets all the metrics properties
@@ -48,6 +51,9 @@ func (s *CrawlerServiceMetrics) InitMetrics() {
 	s.ipv6Nodes5Days = s.metrics.newGauge(chiaServiceCrawler, "ipv6_nodes_5_days", "Total number of IPv6 nodes that have been gossiped around the network with a timestamp in the last 5 days. The crawler did not necessarily connect to all of these peers itself.")
 	s.versionBuckets = s.metrics.newGaugeVec(chiaServiceCrawler, "peer_version", "Number of peers for each version. Only peers the crawler was able to connect to are included here.", []string{"version"})
 	s.countryNodeCountBuckets = s.metrics.newGaugeVec(chiaServiceCrawler, "country_node_count", "Number of peers gossiped in the last 5 days from each country.", []string{"country", "country_display"})
+
+	// Debug Metric
+	s.debug = s.metrics.newGaugeVec(chiaServiceCrawler, "debug_metrics", "random debugging metrics distinguished by labels", []string{"key"})
 
 	err := s.initMaxmindDB()
 	if err != nil {
@@ -104,6 +110,8 @@ func (s *CrawlerServiceMetrics) ReceiveResponse(resp *types.WebsocketResponse) {
 		fallthrough
 	case "crawl_batch_completed":
 		s.GetPeerCounts(resp)
+	case "debug":
+		debugHelper(resp, s.debug)
 	}
 }
 

--- a/internal/metrics/farmer.go
+++ b/internal/metrics/farmer.go
@@ -47,6 +47,9 @@ type FarmerServiceMetrics struct {
 	totalEligiblePlots *prometheus.CounterVec
 	lastEligiblePlots  *prometheus.GaugeVec
 	lastLookupTime     *prometheus.GaugeVec
+
+	// Debug Metric
+	debug *prometheus.GaugeVec
 }
 
 // InitMetrics sets all the metrics properties
@@ -75,6 +78,9 @@ func (s *FarmerServiceMetrics) InitMetrics() {
 	s.totalEligiblePlots = s.metrics.newCounterVec(chiaServiceFarmer, "total_eligible_plots", "Counter of total eligible plots since the exporter started", []string{"host", "node_id"})
 	s.lastEligiblePlots = s.metrics.newGaugeVec(chiaServiceFarmer, "last_eligible_plots", "Number of eligible plots for the last farmer_info event", []string{"host", "node_id"})
 	s.lastLookupTime = s.metrics.newGaugeVec(chiaServiceFarmer, "last_lookup_time", "Lookup time for the last farmer_info event", []string{"host", "node_id"})
+
+	// Debug Metric
+	s.debug = s.metrics.newGaugeVec(chiaServiceFarmer, "debug_metrics", "random debugging metrics distinguished by labels", []string{"key"})
 }
 
 // InitialData is called on startup of the metrics server, to allow seeding metrics with current/initial data
@@ -117,6 +123,8 @@ func (s *FarmerServiceMetrics) ReceiveResponse(resp *types.WebsocketResponse) {
 		fallthrough
 	case "close_connection":
 		utils.LogErr(s.metrics.client.FarmerService.GetConnections(&rpc.GetConnectionsOptions{}))
+	case "debug":
+		debugHelper(resp, s.debug)
 	}
 }
 

--- a/internal/metrics/fullnode.go
+++ b/internal/metrics/fullnode.go
@@ -127,7 +127,7 @@ func (s *FullNodeServiceMetrics) InitMetrics() {
 	s.subEpochSummaries = s.metrics.newGauge(chiaServiceFullNode, "sub_epoch_summaries_filesize", "Size of sub_epoch_summaries file")
 
 	// Debug Metric
-	s.debug = s.metrics.newGaugeVec(chiaServiceFullNode, "debug_metrics", "random debugging metrics distinguished by labels", []string{"key"})
+	s.debug = s.metrics.newGaugeVec(chiaServiceFullNode, "debug_metrics", "misc debugging metrics distinguished by labels", []string{"key"})
 }
 
 // InitialData is called on startup of the metrics server, to allow seeding metrics with

--- a/internal/metrics/fullnode.go
+++ b/internal/metrics/fullnode.go
@@ -205,7 +205,7 @@ func (s *FullNodeServiceMetrics) ReceiveResponse(resp *types.WebsocketResponse) 
 	case "signage_point":
 		s.SignagePoint(resp)
 	case "debug":
-		s.Debug(resp)
+		debugHelper(resp, s.debug)
 	}
 }
 
@@ -340,25 +340,6 @@ func (s *FullNodeServiceMetrics) SignagePoint(resp *types.WebsocketResponse) {
 	s.totalSignagePoints.Inc()
 	s.signagePointsSubSlot.Set(float64(64))
 	s.currentSignagePoint.Set(float64(signagePoint.BroadcastFarmer.SignagePointIndex))
-}
-
-// Debug handles debug events
-// Expects map[string]number - where number is able to be parsed into a float64 type
-// Assigns the key (string) as the "key" label on the metric, and passes the value straight through
-func (s *FullNodeServiceMetrics) Debug(resp *types.WebsocketResponse) {
-	type debugEvent struct {
-		Data map[string]float64 `json:"data"`
-	}
-	debugMetrics := debugEvent{}
-	err := json.Unmarshal(resp.Data, &debugMetrics)
-	if err != nil {
-		log.Errorf("Error unmarshalling debugMetrics: %s\n", err.Error())
-		return
-	}
-
-	for key, value := range debugMetrics.Data {
-		s.debug.WithLabelValues(key).Set(value)
-	}
 }
 
 // RefreshFileSizes periodically checks how large files related to the full node are

--- a/internal/metrics/fullnode.go
+++ b/internal/metrics/fullnode.go
@@ -346,14 +346,17 @@ func (s *FullNodeServiceMetrics) SignagePoint(resp *types.WebsocketResponse) {
 // Expects map[string]number - where number is able to be parsed into a float64 type
 // Assigns the key (string) as the "key" label on the metric, and passes the value straight through
 func (s *FullNodeServiceMetrics) Debug(resp *types.WebsocketResponse) {
-	debugMetrics := map[string]float64{}
+	type debugEvent struct {
+		Data map[string]float64 `json:"data"`
+	}
+	debugMetrics := debugEvent{}
 	err := json.Unmarshal(resp.Data, &debugMetrics)
 	if err != nil {
 		log.Errorf("Error unmarshalling debugMetrics: %s\n", err.Error())
 		return
 	}
 
-	for key, value := range debugMetrics {
+	for key, value := range debugMetrics.Data {
 		s.debug.WithLabelValues(key).Set(value)
 	}
 }

--- a/internal/metrics/harvester.go
+++ b/internal/metrics/harvester.go
@@ -38,6 +38,9 @@ type HarvesterServiceMetrics struct {
 	totalEligiblePlots *wrappedPrometheus.LazyCounter
 	lastEligiblePlots  *wrappedPrometheus.LazyGauge
 	lastLookupTime     *wrappedPrometheus.LazyGauge
+
+	// Debug Metric
+	debug *prometheus.GaugeVec
 }
 
 // InitMetrics sets all the metrics properties
@@ -57,6 +60,9 @@ func (s *HarvesterServiceMetrics) InitMetrics() {
 	s.lastEligiblePlots = s.metrics.newGauge(chiaServiceHarvester, "last_eligible_plots", "Number of eligible plots for the last farmer_info event")
 
 	s.lastLookupTime = s.metrics.newGauge(chiaServiceHarvester, "last_lookup_time", "Lookup time for the last farmer_info event")
+
+	// Debug Metric
+	s.debug = s.metrics.newGaugeVec(chiaServiceHarvester, "debug_metrics", "random debugging metrics distinguished by labels", []string{"key"})
 }
 
 // InitialData is called on startup of the metrics server, to allow seeding metrics with current/initial data
@@ -111,6 +117,8 @@ func (s *HarvesterServiceMetrics) ReceiveResponse(resp *types.WebsocketResponse)
 		s.FarmingInfo(resp)
 	case "get_plots":
 		s.GetPlots(resp)
+	case "debug":
+		debugHelper(resp, s.debug)
 	}
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -320,3 +320,23 @@ func connectionCountHelper(resp *types.WebsocketResponse, connectionCount *prome
 	connectionCount.WithLabelValues("introducer").Set(introducer)
 	connectionCount.WithLabelValues("wallet").Set(wallet)
 }
+
+type debugEvent struct {
+	Data map[string]float64 `json:"data"`
+}
+
+// debugHelper handles debug events
+// Expects map[string]number - where number is able to be parsed into a float64 type
+// Assigns the key (string) as the "key" label on the metric, and passes the value straight through
+func debugHelper(resp *types.WebsocketResponse, debugGaugeVec *prometheus.GaugeVec) {
+	debugMetrics := debugEvent{}
+	err := json.Unmarshal(resp.Data, &debugMetrics)
+	if err != nil {
+		log.Errorf("Error unmarshalling debugMetrics: %s\n", err.Error())
+		return
+	}
+
+	for key, value := range debugMetrics.Data {
+		debugGaugeVec.WithLabelValues(key).Set(value)
+	}
+}

--- a/internal/metrics/timelord.go
+++ b/internal/metrics/timelord.go
@@ -25,6 +25,9 @@ type TimelordServiceMetrics struct {
 	slowTimelord       *wrappedPrometheus.LazyCounter
 	estimatedIPS       *wrappedPrometheus.LazyGauge
 	compactProofsFound *prometheus.CounterVec
+
+	// Debug Metric
+	debug *prometheus.GaugeVec
 }
 
 // InitMetrics sets all the metrics properties
@@ -33,6 +36,9 @@ func (s *TimelordServiceMetrics) InitMetrics() {
 	s.slowTimelord = s.metrics.newCounter(chiaServiceTimelord, "slow_timelord", "Counter for how many times this timelord has NOT been the fastest since the exporter has been running")
 	s.estimatedIPS = s.metrics.newGauge(chiaServiceTimelord, "estimated_ips", "Current estimated IPS. Updated every time a new PoT Challenge is complete")
 	s.compactProofsFound = s.metrics.newCounterVec(chiaServiceTimelord, "compact_proofs_completed", "Count of the number of compact proofs by proof type since the exporter was started", []string{"vdf_field"})
+
+	// Debug Metric
+	s.debug = s.metrics.newGaugeVec(chiaServiceTimelord, "debug_metrics", "random debugging metrics distinguished by labels", []string{"key"})
 }
 
 // InitialData is called on startup of the metrics server, to allow seeding metrics with
@@ -69,6 +75,8 @@ func (s *TimelordServiceMetrics) ReceiveResponse(resp *types.WebsocketResponse) 
 		s.SkippingPeak(resp)
 	case "new_peak":
 		s.NewPeak(resp)
+	case "debug":
+		debugHelper(resp, s.debug)
 	}
 }
 

--- a/internal/metrics/wallet.go
+++ b/internal/metrics/wallet.go
@@ -33,6 +33,9 @@ type WalletServiceMetrics struct {
 	maxSendAmount           *prometheus.GaugeVec
 	pendingCoinRemovalCount *prometheus.GaugeVec
 	unspentCoinCount        *prometheus.GaugeVec
+
+	// Debug Metric
+	debug *prometheus.GaugeVec
 }
 
 // InitMetrics sets all the metrics properties
@@ -48,6 +51,9 @@ func (s *WalletServiceMetrics) InitMetrics() {
 	s.maxSendAmount = s.metrics.newGaugeVec(chiaServiceWallet, "max_send_amount", "", walletLabels)
 	s.pendingCoinRemovalCount = s.metrics.newGaugeVec(chiaServiceWallet, "pending_coin_removal_count", "", walletLabels)
 	s.unspentCoinCount = s.metrics.newGaugeVec(chiaServiceWallet, "unspent_coin_count", "", walletLabels)
+
+	// Debug Metric
+	s.debug = s.metrics.newGaugeVec(chiaServiceWallet, "debug_metrics", "misc debugging metrics distinguished by labels", []string{"key"})
 }
 
 // InitialData is called on startup of the metrics server, to allow seeding metrics with
@@ -98,6 +104,8 @@ func (s *WalletServiceMetrics) ReceiveResponse(resp *types.WebsocketResponse) {
 		s.GetWalletBalance(resp)
 	case "get_wallets":
 		s.GetWallets(resp)
+	case "debug":
+		debugHelper(resp, s.debug)
 	}
 }
 


### PR DESCRIPTION
Allows sending arbitrary string keys/numeric values to any of the supported services and exporting those as metrics.