### PR TITLE
Add tracking around calls we initiate to limit to one at a time

### DIFF
--- a/internal/metrics/farmer.go
+++ b/internal/metrics/farmer.go
@@ -137,6 +137,7 @@ func (s *FarmerServiceMetrics) GetConnections(resp *types.WebsocketResponse) {
 	s.GetHarvesters()
 }
 
+// GetHarvesters loads data about harvesters connected to the farmer
 func (s *FarmerServiceMetrics) GetHarvesters() {
 	if s.gettingHarvesters {
 		log.Debug("Skipping get_harvesters since another request is already in flight")

--- a/internal/metrics/farmer.go
+++ b/internal/metrics/farmer.go
@@ -51,7 +51,7 @@ type FarmerServiceMetrics struct {
 	// Debug Metric
 	debug *prometheus.GaugeVec
 
-	// Make sure we don't ask for harvesters again if another request is still processing
+	// Tracking certain requests to make sure only one happens at any given time
 	gettingHarvesters bool
 }
 
@@ -139,6 +139,7 @@ func (s *FarmerServiceMetrics) GetConnections(resp *types.WebsocketResponse) {
 
 func (s *FarmerServiceMetrics) GetHarvesters() {
 	if s.gettingHarvesters {
+		log.Debug("Skipping get_harvesters since another request is already in flight")
 		return
 	}
 	s.gettingHarvesters = true


### PR DESCRIPTION
In a lot of cases these weren't issues, but I suspect with higher timeout values set, we could have been stacking multiple calls at once. 

Hoping this helps with #121 