### PR TITLE
Chia version metric for all services

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -500,6 +500,17 @@ func connectionCountHelper(resp *types.WebsocketResponse, connectionCount *prome
 	connectionCount.WithLabelValues("wallet").Set(wallet)
 }
 
+func versionHelper(resp *types.WebsocketResponse, versionMetric *prometheus.GaugeVec) {
+	version := &rpc.GetVersionResponse{}
+	err := json.Unmarshal(resp.Data, version)
+	if err != nil {
+		log.Errorf("Error unmarshalling: %s\n", err.Error())
+		return
+	}
+
+	versionMetric.WithLabelValues(version.Version).Set(1)
+}
+
 type debugEvent struct {
 	Data map[string]float64 `json:"data"`
 }


### PR DESCRIPTION
Add a metric on each service that shows the chia version for the running instance of the service.

The version is a label on the metric, and the value is always 1, since metric values have to be numeric.

Full node example:
`chia_full_node_version{network="mainnet",version="2.4.3"} 1`

Resolves #177