### PR TITLE
Update Managed Files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,13 +62,16 @@ $(TEST_TARGETS): test
 check test tests: fmt lint vet staticcheck errcheck vulncheck; $(info $(M) running $(NAME:%=% )tests…) @ ## Run tests
 	$Q $(GO) test -timeout $(TIMEOUT)s $(ARGS) $(TESTPKGS)
 
-.PHONY: lint
-lint: | $(GOLINT) ; $(info $(M) running golint…) @ ## Run golint
-	$Q $(GOLINT) -set_exit_status $(PKGS)
-
 .PHONY: fmt
 fmt: ; $(info $(M) running gofmt…) @ ## Run gofmt on all source files
 	$Q $(GO) fmt $(PKGS)
+
+# Run fmt before any linter so parallel `-jN` doesn't change files while a linter is mid flight.
+lint vet staticcheck errcheck vulncheck: fmt
+
+.PHONY: lint
+lint: | $(GOLINT) ; $(info $(M) running golint…) @ ## Run golint
+	$Q $(GOLINT) -set_exit_status $(PKGS)
 
 .PHONY: vet
 vet: ; $(info $(M) running go vet…) @ ## Run go vet on all source files


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk Makefile change that only adjusts task dependencies to prevent `gofmt` from running concurrently with linters in parallel builds.
> 
> **Overview**
> Ensures `fmt` runs **before** `lint`/`vet`/`staticcheck`/`errcheck`/`vulncheck` by adding a shared dependency, preventing `make -j` from modifying files while a linter is running.
> 
> No functional code changes; this only affects the build/test workflow ordering in `Makefile`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74d0bc925f506fed17c447b124e20ced3fb6d510. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->